### PR TITLE
rebar.config path edit

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
-{deps, [{lager,  "2.0.0", {git, "git@github.com:basho/lager.git",   "master"}},
-        {eper,   "0.60",  {git, "git@github.com:mhald/eper.git",      "HEAD"}},
+{deps, [{lager,  "2.0.0", {git, "git://github.com/basho/lager.git",   "master"}},
+        {eper,   "0.60",  {git, "git://github.com/mhald/eper.git",      "HEAD"}},
         {erldis, "\.*", {git, "git://github.com/inaka/erldis.git", "master"}},
         {eleveldb, "\.*", {git, "git://github.com/inaka/eleveldb.git", "master"}},
         {hanoidb, "\.*", {git, "git://github.com/basho-labs/hanoidb.git", "master"}}]}.


### PR DESCRIPTION
Because it was not a dedicated path of github repository is read, it has changed the path of the repository.
