### PR TITLE
fix edis build on osx

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
-{deps, [{lager,  "2.0.0", {git, "git://github.com/basho/lager.git", "master"}},
+{deps, [{lager,  "2.0.*", {git, "git://github.com/basho/lager.git", "master"}},
         {eper,   "0.*", {git, "git://github.com/massemanet/eper.git", "master"}},
         {erldis, "\.*", {git, "git://github.com/inaka/erldis.git", "master"}},
-        {eleveldb, "\.*", {git, "git://github.com/inaka/eleveldb.git", "master"}},
+        {eleveldb, "\.*", {git, "git://github.com/basho/eleveldb.git", "master"}},
         {hanoidb, "\.*", {git, "git://github.com/basho-labs/hanoidb.git", "master"}}]}.
 {require_otp_vsn, "R1[45]"}.
 {erl_first_files, ["src/edis_backend.erl", "test/edis_bench.erl"]}.


### PR DESCRIPTION
It wasn't building on my OSX mavericks machine, so I changed the dependencies slightly.

Lager master is currently at 2.0.3 so wildcard the patch version. 
Inaka version of eleveldb fails to build on my OS-X Mavericks boxen (lots of pthread type errors).
Basho version of eleveldb builds correctly. 
