### PR TITLE
Added R16b support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,10 +2,11 @@
         {eper,   "0.*", {git, "git://github.com/massemanet/eper.git", "master"}},
         {erldis, "\.*", {git, "git://github.com/inaka/erldis.git", "master"}},
         {eleveldb, "\.*", {git, "git://github.com/basho/eleveldb.git", "master"}},
-        {hanoidb, "\.*", {git, "git://github.com/basho-labs/hanoidb.git", "master"}}]}.
-{require_otp_vsn, "R1[45]"}.
+        {hanoidb, "\.*", {git, "git://github.com/basho-labs/hanoidb.git", "master"}},
+        {pmod_transform, ".*", {git,"git://github.com/erlang/pmod_transform.git", "master"}}]}.
+{require_otp_vsn, "R1[456]"}.
 {erl_first_files, ["src/edis_backend.erl", "test/edis_bench.erl"]}.
-{erl_opts, [{parse_transform, lager_transform}, 
+{erl_opts, [{parse_transform, lager_transform},
             {src_dirs, ["src", "src/backends", "tests", "test/benchmarks"]},
             %{i, "deps/lager/include"},
             warn_unused_vars,

--- a/src/edis_gb_trees.erl
+++ b/src/edis_gb_trees.erl
@@ -10,6 +10,8 @@
 -author('Fernando Benavides <fernando.benavides@inakanetworks.com>').
 -author('Chad DePue <chad@inakanetworks.com>').
 
+-compile({parse_transform,pmod_pt}).
+
 -export([rev_iterator/1, previous/1]).
 
 -type edis_gb_tree() :: gb_tree().


### PR DESCRIPTION
Hi, 

The `edis_gb_trees` module extends `gb_trees` with the use of an `-extends` directive. 

This commit adds support for Erlang/OTP R16 thanks to the `pmod_pt` parse tranform. I've been able to test using `ZADD`, `ZRANGE`, etc. commands.

As most of you already now, this parse_transform handles `-extends` directive with `$handle_undefined_function`.
