### PR TITLE
updates location of erldis

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {deps, [{lager,  "2.0.*", {git, "git://github.com/basho/lager.git", "master"}},
         {eper,   "0.*", {git, "git://github.com/massemanet/eper.git", "master"}},
-        {erldis, "\.*", {git, "git://github.com/inaka/erldis.git", "master"}},
+        {erldis, "\.*", {git, "git://github.com/japerk/erldis.git", "master"}},
         {eleveldb, "\.*", {git, "git://github.com/basho/eleveldb.git", "master"}},
         {hanoidb, "\.*", {git, "git://github.com/basho-labs/hanoidb.git", "master"}},
         {pmod_transform, ".*", {git,"git://github.com/erlang/pmod_transform.git", "master"}}]}.


### PR DESCRIPTION
git://github.com/inaka/erldis.git is not available. changing to git://github.com/japerk/erldis.git
